### PR TITLE
Yaml specification

### DIFF
--- a/config/tables.yml
+++ b/config/tables.yml
@@ -1,2 +1,2 @@
 parameters:
-    primehalo.primepostrevisions.tables.primepostrev: %core.table_prefix%primepostrev
+    primehalo.primepostrevisions.tables.primepostrev: '%core.table_prefix%primepostrev'


### PR DESCRIPTION
According to Yaml specification, unquoted strings cannot start with @, %, `, | or >. You must wrap these strings with single or double quotes.