### PR TITLE
Display Diff as Post

### DIFF
--- a/styles/prosilver/template/event/overall_footer_body_after.html
+++ b/styles/prosilver/template/event/overall_footer_body_after.html
@@ -3,8 +3,8 @@
 	<div class="inner">
 		<dl class="postprofile">
 			<dt class="has-avatar">
-				<div style="text-align:center;display:flex;flex-direction:column;justify-content:center;font-size:5vmin;">
-					<i class="fa fa-arrow-up fa-5x"></i>
+				<div style="text-align:center;display:flex;flex-direction:column;justify-content:center;font-size:10vmin;">
+					<i class="fa fa-arrow-up"></i>
 				</div>
 			</dt>
 		</dl>

--- a/styles/prosilver/template/event/overall_footer_body_after.html
+++ b/styles/prosilver/template/event/overall_footer_body_after.html
@@ -1,8 +1,16 @@
 <script id="ppr-cmpout-tpl" type="text/x-jsrender">
-<div class="post comparison" id="<<:cmpId>>" style="display:none;">
+<div class="post has-profile bg3 comparison" id="<<:cmpId>>" style="display:none;">
 	<div class="inner">
-		<div class="postprofile" style="text-align:center;display:flex;flex-direction:column;justify-content:center;"><i class="fa fa-arrow-up fa-5x"></i></div>
-		<<:cmpHtml>>
+		<dl class="postprofile">
+			<dt class="has-avatar">
+				<div style="text-align:center;display:flex;flex-direction:column;justify-content:center;font-size:5vmin;">
+					<i class="fa fa-arrow-up fa-5x"></i>
+				</div>
+			</dt>
+		</dl>
+		<div class="postbody">
+			<div class="content"><<:cmpHtml>></div>
+		</div>
 	</div>
 </div>
 </script>


### PR DESCRIPTION
Previously :
![Previous](https://i.imgur.com/VySrNUG.png)
After this PR : 
![1](https://user-images.githubusercontent.com/25451052/79112057-594f6600-7d9b-11ea-8b93-a0b4c8d5578c.png)
Also Responsive : 
![2](https://user-images.githubusercontent.com/25451052/79112084-6a987280-7d9b-11ea-854f-a250e551f635.PNG)
& the arrow becomes smaller with screen size : 
![3](https://user-images.githubusercontent.com/25451052/79112100-71bf8080-7d9b-11ea-8fc6-907cdbb875fa.PNG)

My suggestion is to move everything from `styles/prosilver` to `styles/all` ,
since after this PR it is compatible with all or atleast most `prosilver` based or derived themes.
Other incompatible themes can make their own changes which will overwrite `prosilver` files in their own dirs.

I hope you like it.

If any changes are required , then let me know.

Best regards 👍 