### PR TITLE
Comparisons of 2 Revisions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,12 @@
 			"email": "primehalo@gmail.com",
 			"homepage": "https://www.absoluteanime.com/",
 			"role": "Lead Developer"
+		},
+		{
+			"name": "Dark❶",
+			"email": "phpbb@dark1.tech",
+			"homepage": "https://dark1.tech",
+			"role": "Contributor"
 		}
 	],
 	"require": {

--- a/config/routing.yml
+++ b/config/routing.yml
@@ -1,17 +1,18 @@
 primehalo_primepostrevisions_view:
     path: /revisions/view/{post_id}
-    defaults: { _controller: primehalo.primepostrevisions.controller:view }
+    defaults: { _controller: primehalo.primepostrevisions.controller:view, post_id: 0, revision_id: false }
     requirements:
         post_id: \d+
+        revision_id: \d+|false
 
 primehalo_primepostrevisions_delete:
     path: /revisions/delete/{revision_id}
-    defaults: { _controller: primehalo.primepostrevisions.controller:delete }
+    defaults: { _controller: primehalo.primepostrevisions.controller:delete, revision_id: 0, s_hidden_fields: '' }
     requirements:
         revision_id: \d+
 
 primehalo_primepostrevisions_restore:
     path: /revisions/restore/{revision_id}
-    defaults: { _controller: primehalo.primepostrevisions.controller:restore }
+    defaults: { _controller: primehalo.primepostrevisions.controller:restore, revision_id: 0 }
     requirements:
         revision_id: \d+

--- a/controller/controller.php
+++ b/controller/controller.php
@@ -81,18 +81,26 @@ class controller
 	/**
 	* Build the page for viewing all revisions of a post.
 	*
-	* @param int $post_id The ID of the post whose revisions we want to view
+	* @param	int				$post_id		The ID of the post whose revisions we want to view
+	* @param	bool|int|array	$revision_id	An ID or an array of IDs of the revisions to be compared
 	* @return Symphony Response object
 	* @access public
 	*/
-	public function view($post_id)
+	public function view($post_id, $revision_id = false)
 	{
+		if ($revision_id !== false)
+		{
+			$rev_min	= min($revision_id);
+			$rev_max	= max($revision_id);
+			$rev_list	= array(($rev_min != $rev_max) ? $rev_min : 0 , $rev_max);
+		}
+
 		// Obtain the current version of the post
 		$sql = $this->db->sql_build_query('SELECT', array(
 			'SELECT'	=> 'p.forum_id, p.poster_id, p.post_time, p.post_subject, p.post_text, p.primepost_edit_time,
 							p.post_edit_reason, p.primepost_edit_user, p.primepost_edit_count, p.bbcode_bitfield, p.bbcode_uid, u.*',
-			'FROM'		=> array(POSTS_TABLE => 'p', USERS_TABLE => 'u'),
-			'WHERE'		=> 'post_id = ' . $post_id . ' AND ((p.primepost_edit_user = 0 AND p.poster_id = u.user_id) OR p.primepost_edit_user = u.user_id)',
+			'FROM'		=> array($this->revisions_table => 'r', POSTS_TABLE => 'p', USERS_TABLE => 'u'),
+			'WHERE'		=> 'p.post_id = ' . $post_id . (($revision_id !== false) ? ' AND ' . $this->db->sql_in_set('r.revision_id', $rev_list) : '') . ' AND ((p.primepost_edit_user = 0 AND p.poster_id = u.user_id) OR p.primepost_edit_user = u.user_id)',
 		));
 		$result		= $this->db->sql_query($sql);
 		$post_data	= $this->db->sql_fetchrow($result);
@@ -104,16 +112,19 @@ class controller
 		$post_link	= "<a href=\"{$post_url}\">{$this->user->lang['VIEW_LATEST_POST']}</a>";
 		$s_hidden_fields = build_hidden_fields(array(
 			'revision_list'	=> array_filter($this->request->variable('revision_list', array(0))),
-			'action'		=> 'delete',
 		));
 
-		// Delete button was pressed
-		if ($this->request->variable('action', '') === 'delete')
+		// Delete or Compare button was pressed
+		if ($this->request->is_set_post('delete') || ($this->request->is_set_post('compare') && $revision_id === false))
 		{
 			$revision_list = array_filter($this->request->variable('revision_list', array(0)));
-			if (!empty($revision_list))
+			if (!empty($revision_list) && check_form_key('revisions_form'))
 			{
-				return $this->delete($revision_list, $s_hidden_fields);
+				return ($this->request->is_set_post('delete')) ? $this->delete($revision_list, $s_hidden_fields) : $this->view($post_id, $revision_list);
+			}
+			else
+			{
+				trigger_error('FORM_INVALID', E_USER_WARNING);
 			}
 		}
 
@@ -127,20 +138,23 @@ class controller
 		$user_cache		= array();
 		$deletable_cnt	= 0;
 		$revision_cnt	= 0;
-		$page_name		= $this->user->lang['PRIMEPOSTREVISIONS_VIEWING'];
+		$page_name		= ($revision_id !== false) ? $this->user->lang['PRIMEPOSTREVISIONS_COMPARING'] : $this->user->lang['PRIMEPOSTREVISIONS_VIEWING'];
 		$can_delete		= $this->core->is_auth('delete', $forum_id, $post_data['poster_id']);
 		$can_restore	= $this->core->is_auth('restore', $forum_id, $post_data['poster_id']);
 
 		// Get data about the list of revisions and the users that edited them
 		$sql = "SELECT r.*, u.* FROM {$this->revisions_table} r, " . USERS_TABLE . " u
-				WHERE r.post_id = {$post_id} AND ((r.primepost_edit_user = 0 AND u.user_id = {$post_data['poster_id']}) OR r.primepost_edit_user = u.user_id)
+				WHERE " . (($revision_id !== false) ? $this->db->sql_in_set('r.revision_id', $rev_list) . ' AND ' : '') . "r.post_id = {$post_id} AND ((r.primepost_edit_user = 0 AND u.user_id = {$post_data['poster_id']}) OR r.primepost_edit_user = u.user_id)
 				ORDER BY revision_id DESC";
 		$result = $this->db->sql_query($sql);
 		$revisions = $this->db->sql_fetchrowset($result);
 		$this->db->sql_freeresult($result);
 
 		// Add the current version of the post to the list
-		array_unshift($revisions, $post_data);
+		if ($revision_id === false || ($revision_id !== false && in_array(0, $rev_list)))
+		{
+			array_unshift($revisions, $post_data);
+		}
 
 		// Include the file necessary for obtaining user rank & also for generation of text for display & edit
 		if (!function_exists('phpbb_get_user_rank') || !function_exists('generate_text_for_display') || !function_exists('generate_text_for_edit'))
@@ -193,21 +207,21 @@ class controller
 				);
 			}
 
-			$revision_id	= empty($row['revision_id']) ? 0 :  $row['revision_id'];
+			$post_rev_id	= empty($row['revision_id']) ? 0 :  $row['revision_id'];
 			$parse_flags	= ($row['bbcode_bitfield'] ? OPTION_FLAG_BBCODE : 0) | OPTION_FLAG_SMILIES;
 			$post_text		= generate_text_for_display($row['post_text'], $row['bbcode_uid'], $row['bbcode_bitfield'], $parse_flags);
 			$post_date		= empty($row['primepost_edit_time']) ? $post_data['post_time'] : $row['primepost_edit_time'];
-			$delete_url		= ($can_delete && !empty($revision_id)) ? $this->helper->route('primehalo_primepostrevisions_delete', array('revision_id' => $revision_id)) : false;
-			$restore_url	= ($can_restore && !empty($revision_id)) ? $this->helper->route('primehalo_primepostrevisions_restore', array('revision_id' => $revision_id)) : false;
+			$delete_url		= ($can_delete && !empty($post_rev_id)) ? $this->helper->route('primehalo_primepostrevisions_delete', array('revision_id' => $post_rev_id)) : false;
+			$restore_url	= ($can_restore && !empty($post_rev_id)) ? $this->helper->route('primehalo_primepostrevisions_restore', array('revision_id' => $post_rev_id)) : false;
 			$reason			= $row['post_edit_reason'];
 			$edit_count_str	= sprintf($this->user->lang['PRIMEPOSTREVISIONS_COUNT'], $row['primepost_edit_count']);
 			$edit_count_str	= empty($row['primepost_edit_count']) ? $this->user->lang['PRIMEPOSTREVISIONS_FIRST'] : $edit_count_str;
-			$edit_count_str	= empty($revision_id) ? $this->user->lang['PRIMEPOSTREVISIONS_FINAL'] : $edit_count_str;
+			$edit_count_str	= empty($post_rev_id) ? $this->user->lang['PRIMEPOSTREVISIONS_FINAL'] : $edit_count_str;
 			$deletable_cnt	+= $delete_url ? 1 : 0;
 			$bbcode_text	= generate_text_for_edit($row['post_text'], $row['bbcode_uid'], 0)['text'];
 
 			$this->template->assign_block_vars('postrow',array(
-				'REVISION_ID'		=> $revision_id,
+				'REVISION_ID'		=> $post_rev_id,
 				'POST_ID'			=> $post_id,
 				'POST_DATE'			=> $this->user->format_date($post_date),
 				'POST_TEXT'			=> $post_text,
@@ -244,6 +258,7 @@ class controller
 		add_form_key('revisions_form');
 		$this->template->assign_vars(array(
 			'REVISIONS'			=> true,
+			'COMPARISONS'		=> ($revision_id !== false) ? false : true,
 			'POST_SUBJECT'		=> $post_data['post_subject'],
 			'U_POST'			=> $post_url,
 			'POST_ID'			=> $post_id,

--- a/controller/controller.php
+++ b/controller/controller.php
@@ -88,17 +88,23 @@ class controller
 	*/
 	public function view($post_id, $revision_id = false)
 	{
+		$comparing_selected = false;	// Are we comparing selected revisions?
+		$rev_list = array();			// List of revision IDs to compare
+
 		if ($revision_id !== false)
 		{
-			$rev_list	= is_array($revision_id) ? (count($revision_id) > 1 ? $revision_id : array_merge(array(0), $revision_id)) : array(0, $revision_id);
+			$rev_list = is_array($revision_id) ? (count($revision_id) > 1 ? $revision_id : array_merge(array(0), $revision_id)) : array(0, $revision_id);
+			$comparing_selected = true;
 		}
 
-		// Obtain the current version of the post
+		// Obtain the current version of the post as well as data for the last person to edit it
 		$sql = $this->db->sql_build_query('SELECT', array(
 			'SELECT'	=> 'p.forum_id, p.poster_id, p.post_time, p.post_subject, p.post_text, p.primepost_edit_time,
 							p.post_edit_reason, p.primepost_edit_user, p.primepost_edit_count, p.bbcode_bitfield, p.bbcode_uid, u.*',
 			'FROM'		=> array($this->revisions_table => 'r', POSTS_TABLE => 'p', USERS_TABLE => 'u'),
-			'WHERE'		=> 'p.post_id = ' . $post_id . (($revision_id !== false) ? ' AND ' . $this->db->sql_in_set('r.revision_id', $rev_list) : '') . ' AND ((p.primepost_edit_user = 0 AND p.poster_id = u.user_id) OR p.primepost_edit_user = u.user_id)',
+			'WHERE'		=> "p.post_id = $post_id" .
+							($comparing_selected ? ' AND ' . $this->db->sql_in_set('r.revision_id', $rev_list) : '') .
+							' AND ((p.primepost_edit_user = 0 AND p.poster_id = u.user_id) OR p.primepost_edit_user = u.user_id)',
 		));
 		$result		= $this->db->sql_query($sql);
 		$post_data	= $this->db->sql_fetchrow($result);
@@ -109,14 +115,14 @@ class controller
 		$post_url	= $this->core->build_post_url($post_id);
 		$post_link	= "<a href=\"{$post_url}\">{$this->user->lang['VIEW_LATEST_POST']}</a>";
 		$s_hidden_fields = build_hidden_fields(array(
-			'revision_list_compare'	=> array_filter($this->request->variable('revision_list_compare', array(0))),
-			'revision_list_delete'	=> array_filter($this->request->variable('revision_list_delete', array(0)))
+			'revision_list_compare'	=> $this->request->variable('revision_list_compare', array(0)),
+			'revision_list_delete'	=> array_filter($this->request->variable('revision_list_delete', array(0))) 	// Remove all non-empty values from the array
 		));
 
 		// Compare button was pressed
-		if ($this->request->is_set_post('compare') && $revision_id === false)
+		if ($this->request->is_set_post('compare') && !$comparing_selected)
 		{
-			$revision_list_compare = array_filter($this->request->variable('revision_list_compare', array(0)));
+			$revision_list_compare = $this->request->variable('revision_list_compare', array(0));
 			if (!empty($revision_list_compare) && check_form_key('revisions_form'))
 			{
 				return $this->view($post_id, $revision_list_compare);
@@ -130,7 +136,7 @@ class controller
 		// Delete button was pressed
 		if ($this->request->is_set_post('delete'))
 		{
-			$revision_list_delete = array_filter($this->request->variable('revision_list_delete', array(0)));
+			$revision_list_delete = array_filter($this->request->variable('revision_list_delete', array(0)));	// Remove all non-empty values from the array
 			if (!empty($revision_list_delete) && check_form_key('revisions_form'))
 			{
 				return $this->delete($revision_list_delete, $s_hidden_fields);
@@ -149,21 +155,24 @@ class controller
 
 		// Prepare some variables
 		$user_cache		= array();
-		$deletable_cnt	= $revision_cnt	= 0;
-		$page_name		= ($revision_id !== false) ? $this->user->lang['PRIMEPOSTREVISIONS_COMPARING'] : $this->user->lang['PRIMEPOSTREVISIONS_VIEWING'];
+		$deletable_cnt	= 0;	// Total number of revisions that can be deleted
+		$revision_cnt	= 0;	// Total number of revisions that can be displayed
+		$page_name		= $comparing_selected ? $this->user->lang['PRIMEPOSTREVISIONS_COMPARING'] : $this->user->lang['PRIMEPOSTREVISIONS_VIEWING'];
 		$can_delete		= $this->core->is_auth('delete', $forum_id, $post_data['poster_id']);
 		$can_restore	= $this->core->is_auth('restore', $forum_id, $post_data['poster_id']);
 
 		// Get data about the list of revisions and the users that edited them
 		$sql = "SELECT r.*, u.* FROM {$this->revisions_table} r, " . USERS_TABLE . " u
-				WHERE " . (($revision_id !== false) ? $this->db->sql_in_set('r.revision_id', $rev_list) . ' AND ' : '') . "r.post_id = {$post_id} AND ((r.primepost_edit_user = 0 AND u.user_id = {$post_data['poster_id']}) OR r.primepost_edit_user = u.user_id)
+				WHERE " . ($comparing_selected ? $this->db->sql_in_set('r.revision_id', $rev_list) . ' AND ' : '') .
+						"r.post_id = {$post_id}
+						AND ((r.primepost_edit_user = 0 AND u.user_id = {$post_data['poster_id']}) OR r.primepost_edit_user = u.user_id)
 				ORDER BY revision_id DESC";
 		$result = $this->db->sql_query($sql);
 		$revisions = $this->db->sql_fetchrowset($result);
 		$this->db->sql_freeresult($result);
 
 		// Add the current version of the post to the list
-		if ($revision_id === false || ($revision_id !== false && in_array(0, $rev_list)))
+		if (!$comparing_selected || ($comparing_selected && in_array(0, $rev_list)))
 		{
 			array_unshift($revisions, $post_data);
 		}
@@ -270,7 +279,7 @@ class controller
 		add_form_key('revisions_form');
 		$this->template->assign_vars(array(
 			'REVISIONS'			=> true,
-			'COMPARISONS'		=> $revision_id === false,
+			'COMPARISONS'		=> !$comparing_selected,
 			'POST_SUBJECT'		=> $post_data['post_subject'],
 			'U_POST'			=> $post_url,
 			'POST_ID'			=> $post_id,

--- a/controller/controller.php
+++ b/controller/controller.php
@@ -90,9 +90,7 @@ class controller
 	{
 		if ($revision_id !== false)
 		{
-			$rev_min	= min($revision_id);
-			$rev_max	= max($revision_id);
-			$rev_list	= array(($rev_min != $rev_max) ? $rev_min : 0 , $rev_max);
+			$rev_list	= is_array($revision_id) ? $revision_id : array(0, $revision_id);
 		}
 
 		// Obtain the current version of the post

--- a/controller/controller.php
+++ b/controller/controller.php
@@ -134,8 +134,7 @@ class controller
 
 		// Prepare some variables
 		$user_cache		= array();
-		$deletable_cnt	= 0;
-		$revision_cnt	= 0;
+		$selectable_cnt	= $revision_cnt	= 0;
 		$page_name		= ($revision_id !== false) ? $this->user->lang['PRIMEPOSTREVISIONS_COMPARING'] : $this->user->lang['PRIMEPOSTREVISIONS_VIEWING'];
 		$can_delete		= $this->core->is_auth('delete', $forum_id, $post_data['poster_id']);
 		$can_restore	= $this->core->is_auth('restore', $forum_id, $post_data['poster_id']);
@@ -215,8 +214,8 @@ class controller
 			$edit_count_str	= sprintf($this->user->lang['PRIMEPOSTREVISIONS_COUNT'], $row['primepost_edit_count']);
 			$edit_count_str	= empty($row['primepost_edit_count']) ? $this->user->lang['PRIMEPOSTREVISIONS_FIRST'] : $edit_count_str;
 			$edit_count_str	= empty($post_rev_id) ? $this->user->lang['PRIMEPOSTREVISIONS_FINAL'] : $edit_count_str;
-			$deletable_cnt	+= $delete_url ? 1 : 0;
 			$bbcode_text	= generate_text_for_edit($row['post_text'], $row['bbcode_uid'], 0)['text'];
+			$selectable_cnt	+= $delete_url ? 1 : 0;
 
 			$this->template->assign_block_vars('postrow',array(
 				'REVISION_ID'		=> $post_rev_id,
@@ -262,7 +261,7 @@ class controller
 			'POST_ID'			=> $post_id,
 			'S_FORM_ACTION'		=> $this->helper->route('primehalo_primepostrevisions_view', array('post_id' => $post_id)),
 			'S_HIDDEN_FIELDS'	=> $s_hidden_fields,
-			'DELETABLE_CNT'		=> $deletable_cnt,
+			'SELECTABLE_CNT'	=> $selectable_cnt,
 		));
 
 		return $this->helper->render('body.html', $page_name);

--- a/controller/controller.php
+++ b/controller/controller.php
@@ -270,7 +270,7 @@ class controller
 		add_form_key('revisions_form');
 		$this->template->assign_vars(array(
 			'REVISIONS'			=> true,
-			'COMPARISONS'		=> ($revision_id !== false) ? false : true,
+			'COMPARISONS'		=> $revision_id === false,
 			'POST_SUBJECT'		=> $post_data['post_subject'],
 			'U_POST'			=> $post_url,
 			'POST_ID'			=> $post_id,

--- a/language/ar/common.php
+++ b/language/ar/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[لا عنوان]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'حذف التعديل',

--- a/language/ar/common.php
+++ b/language/ar/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'حذف التعديل',

--- a/language/ar/common.php
+++ b/language/ar/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'المشاركة الأصلية',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'المشاركة الحالية',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'التعديل %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'تم التعديل بواسطة %1$s في %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'تم التعديل بواسطة',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[لا عنوان]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/ar/common.php
+++ b/language/ar/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/ar/common.php
+++ b/language/ar/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'حذف التعديل',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'حذف التعديلات المحددة',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'هل أنت متأكد من أنك تريد حذف هذه التعديلات؟',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'أنت تفتقر إلى الصلاحيات اللازمة لحذف هذه التعديلات.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'حدث خطأ أثناء محاولة حذف هذه التعديلات.',

--- a/language/de/common.php
+++ b/language/de/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Du besitzt nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Lösche die ausgewählte Version',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Lösche die ausgewählten Versionen',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Bist Du sicher, dass Du diese Beitragsversionen löschen willst?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Du besitzt nicht die erforderlichen Rechte zur Löschung dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Beim Versuch die Beitragsversionen zu löschen ist ein Fehler aufgetreten.',

--- a/language/de/common.php
+++ b/language/de/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Du besitzt nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/de/common.php
+++ b/language/de/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[Kein Titel]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Du besitzt nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Lösche die ausgewählte Version',

--- a/language/de/common.php
+++ b/language/de/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Ursprünglicher Beitrag',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Aktueller Beitrag',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Version %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Editiert von %1$s am %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Editiert von',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[Kein Titel]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',

--- a/language/de/common.php
+++ b/language/de/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Du besitzt nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Lösche die ausgewählte Version',

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Sie besitzen nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Sie besitzen nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Lösche diese Version',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Lösche die ausgewählten Versionen',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Sind Sie sicher, dass Sie diese Beitragsversionen löschen wollen?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Sie besitzen nicht die erforderlichen Rechte zur Löschung dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Beim Versuch die Beitragsversionen zu löschen ist ein Fehler aufgetreten.',

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[Kein Titel]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Sie besitzen nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Lösche diese Version',

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Sie besitzen nicht die erforderlichen Rechte zum Anschauen dieser Beitragsversionen.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Lösche diese Version',

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Ursprünglicher Beitrag',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Aktueller Beitrag',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Version %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Editiert von %1$s am %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Editiert von',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[Kein Titel]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergleichen',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Delete Revision',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Delete selected revisions',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Are you sure you want to delete these revisions?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'You lack the necessary permissions to delete these revisions.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'An error occurred while attempting to delete these revisions.',
@@ -79,6 +83,4 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_RESTORE_DENIED'		=> 'You lack the necessary permissions to restore this revision.',
 	'PRIMEPOSTREVISIONS_RESTORE_FAILED'		=> 'An error occurred while attempting to restore the revision.',
 	'PRIMEPOSTREVISIONS_RESTORE_SUCCESS'	=> 'The post has been successfully restored.',
-	'PRIMEPOSTREVISIONS_RESTORE_INVALID'	=> 'No post revision has been selected for restoration.',
-
 ));

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -48,12 +48,14 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Original post',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Current post',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Revision %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Edited by %1$s on %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Edited by',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[no subject]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
-	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Delete Revision',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Delete Revision',

--- a/language/es/common.php
+++ b/language/es/common.php
@@ -49,7 +49,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Mensaje original',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Mensaje actual',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Revisión %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Editado por %1$s en %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Editado por',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[sin asunto]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/es/common.php
+++ b/language/es/common.php
@@ -54,6 +54,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[sin asunto]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Eliminar revisión',

--- a/language/es/common.php
+++ b/language/es/common.php
@@ -54,9 +54,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Eliminar revisión',
@@ -68,6 +71,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Eliminar las revisiones seleccionadas',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> '&iquest;Está seguro que desea eliminar estas revisiones?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'No tiene los permisos necesarios para eliminar estas revisiones.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Se produjo un error al intentar eliminar la revisión.',

--- a/language/es/common.php
+++ b/language/es/common.php
@@ -54,9 +54,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Eliminar revisión',

--- a/language/es/common.php
+++ b/language/es/common.php
@@ -54,7 +54,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/fr/common.php
+++ b/language/fr/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Comparer',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Vous ne disposez pas des autorisations nécessaires pour afficher ces révisions post.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Effacer édition',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Effacer les éditions sélectionnées',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Êtes vous sur de vouloir supprimer ces éditions ?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Vous n’avez pas les permissions nécessaires pour supprimer ces éditions.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Une erreur est apparue pendant la suppression des éditions.',

--- a/language/fr/common.php
+++ b/language/fr/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Comparer',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Vous ne disposez pas des autorisations nécessaires pour afficher ces révisions post.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Effacer édition',

--- a/language/fr/common.php
+++ b/language/fr/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Message initial',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Dernière édition',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Édition %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Édité par %1$s le %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Édité par',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[sans sujet]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Comparer',

--- a/language/fr/common.php
+++ b/language/fr/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Comparer',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Vous ne disposez pas des autorisations nécessaires pour afficher ces révisions post.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/fr/common.php
+++ b/language/fr/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[sans sujet]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Comparer',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Vous ne disposez pas des autorisations nécessaires pour afficher ces révisions post.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Effacer édition',

--- a/language/it/common.php
+++ b/language/it/common.php
@@ -54,9 +54,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Cancella revisione',
@@ -68,6 +71,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Cancella le revisioni selezionate',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Sei sicuro di voler cancellare queste revisioni?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Non hai i permessi necessari per eliminare queste revisioni.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Si e\' verificato un errore mentre si cercava di eliminare queste revisioni.',

--- a/language/it/common.php
+++ b/language/it/common.php
@@ -54,9 +54,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Cancella revisione',

--- a/language/it/common.php
+++ b/language/it/common.php
@@ -49,7 +49,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Messaggio originale',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Messaggio attuale',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Revisione %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Modificato da %1$s il %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Modificato da',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[nessun soggetto]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/it/common.php
+++ b/language/it/common.php
@@ -54,6 +54,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[nessun soggetto]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Cancella revisione',

--- a/language/it/common.php
+++ b/language/it/common.php
@@ -54,7 +54,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Origineel bericht',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Huidig bericht',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Revisie %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Aangepast door %1$s op %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Aangepast door',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[geen onderwerp]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergelijk',

--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[geen onderwerp]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergelijk',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'U mist de nodige rechten om deze post revisies te bekijken.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Verwijder revisie',

--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergelijk',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'U mist de nodige rechten om deze post revisies te bekijken.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Verwijder revisie',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Verwijder geselecteerde revisie',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Weet u zeker dat u deze revisie wilt verwijderen? ',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Je hebt je beschikt niet over voldoende permissies om deze revisie te verwijderen.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Er is een fout opgetreden bij het verwijderen van de revisie.',

--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergelijk',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'U mist de nodige rechten om deze post revisies te bekijken.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Vergelijk',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'U mist de nodige rechten om deze post revisies te bekijken.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Verwijder revisie',

--- a/language/pl/common.php
+++ b/language/pl/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Usuń zmianę',

--- a/language/pl/common.php
+++ b/language/pl/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/pl/common.php
+++ b/language/pl/common.php
@@ -38,7 +38,7 @@ if (empty($lang) || !is_array($lang))
 //
 
 $lang = array_merge($lang, array(
-  // Viewing posts
+	// Viewing posts
 	'PRIMEPOSTREVISIONS_VIEW'				=> 'Zobacz historię postu.',	// Text for the link to view the revision history
 
 	// Viewing revisions
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Usuń zmianę',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Usuń wybrane zmiany',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Jesteś pewny(a), że chcesz usunąć te zmiany?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Nie masz niezbędnych uprawnień, by usunąć te zmiany.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Wystąpił błąd podczas próby usunięcia tych zmian.',
@@ -76,7 +80,7 @@ $lang = array_merge($lang, array(
 	// Restore a revision
 	'PRIMEPOSTREVISIONS_RESTORE'			=> 'Restore Revision',
 	'PRIMEPOSTREVISIONS_RESTORE_CONFIRM'	=> 'Are you sure you want to restore this revision?',
-	'PRIMEPOSTREVISIONS_RESTORE_DENIED'	=> 'You lack the necessary permissions to restore this revision.',
-	'PRIMEPOSTREVISIONS_RESTORE_FAILED'	=> 'An error occurred while attempting to restore the revision.',
+	'PRIMEPOSTREVISIONS_RESTORE_DENIED'		=> 'You lack the necessary permissions to restore this revision.',
+	'PRIMEPOSTREVISIONS_RESTORE_FAILED'		=> 'An error occurred while attempting to restore the revision.',
 	'PRIMEPOSTREVISIONS_RESTORE_SUCCESS'	=> 'The post has been successfully restored.',
 ));

--- a/language/pl/common.php
+++ b/language/pl/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Oryginalny post',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Aktualny post',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Zmiana %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Zmieniony przez %1$s %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Zmieniony przez',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[bez tematu]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/pl/common.php
+++ b/language/pl/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[bez tematu]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Usuń zmianę',

--- a/language/pt_br/common.php
+++ b/language/pt_br/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Você não tem as permissões necessárias para visualizar as revisões do post.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Excluir Revisão',

--- a/language/pt_br/common.php
+++ b/language/pt_br/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[sem assunto]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Você não tem as permissões necessárias para visualizar as revisões do post.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Excluir Revisão',

--- a/language/pt_br/common.php
+++ b/language/pt_br/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Você não tem as permissões necessárias para visualizar as revisões do post.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Excluir Revisão',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Excluir revisões selecionadas',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Quer realmente apagar estas revisões?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Você não tem as permissões necessárias para remover estas revisões.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Ocorreu um erro ao tentar apagar estas revisões.',
@@ -79,6 +83,4 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_RESTORE_DENIED'		=> 'Você não tem as permissões necessárias para restaurar esta revisão.',
 	'PRIMEPOSTREVISIONS_RESTORE_FAILED'		=> 'Ocorreu um erro ao tentar restaurar a revisão.',
 	'PRIMEPOSTREVISIONS_RESTORE_SUCCESS'	=> 'O post foi restaurado com sucesso.',
-	'PRIMEPOSTREVISIONS_RESTORE_INVALID'	=> 'Nenhuma revisão posterior foi selecionada para restauração.',
-
 ));

--- a/language/pt_br/common.php
+++ b/language/pt_br/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Post original',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Post atual',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'revisão %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Editado por %1$s em %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Editado por',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[sem assunto]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/pt_br/common.php
+++ b/language/pt_br/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'Você não tem as permissões necessárias para visualizar as revisões do post.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/ru/common.php
+++ b/language/ru/common.php
@@ -49,7 +49,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Первоначальный текст',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Текущий текст',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Версия %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Отредактировано %1$s %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Отредактировано',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[нет заголовка]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/ru/common.php
+++ b/language/ru/common.php
@@ -54,9 +54,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Удалить версию',
@@ -68,6 +71,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Удалить выбранные версии',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Вы уверены что хотите удалить все версии сообщения?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'У вас отсутствуют права доступа для удаления версий сообщения.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Произошла ошибка при попытке удаления версий сообщения.',

--- a/language/ru/common.php
+++ b/language/ru/common.php
@@ -54,6 +54,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[нет заголовка]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Удалить версию',

--- a/language/ru/common.php
+++ b/language/ru/common.php
@@ -54,7 +54,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/ru/common.php
+++ b/language/ru/common.php
@@ -54,9 +54,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Удалить версию',

--- a/language/sk/common.php
+++ b/language/sk/common.php
@@ -53,9 +53,9 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
-	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
-	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Odstrániť Upravu',

--- a/language/sk/common.php
+++ b/language/sk/common.php
@@ -53,9 +53,12 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+
+	// Compare selected revisions
 	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
+	'PRIMEPOSTREVISIONS_COMPARES_SELECT'	=> 'Select for comparison',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Odstrániť Upravu',
@@ -67,6 +70,7 @@ $lang = array_merge($lang, array(
 
 	// Delete all revisions
 	'PRIMEPOSTREVISIONS_DELETES'			=> 'Odstrániť vybraté úpravy',
+	'PRIMEPOSTREVISIONS_DELETES_SELECT'		=> 'Select for deletion',
 	'PRIMEPOSTREVISIONS_DELETES_CONFIRM'	=> 'Ste si istí, že chcete zmazať tieto upravy?',
 	'PRIMEPOSTREVISIONS_DELETES_DENIED'		=> 'Nemate potrebné povolenia na odstránenie tejto upravy.',
 	'PRIMEPOSTREVISIONS_DELETES_FAILED'		=> 'Došlo k chybe pri pokuse o vymazanie upravy.',

--- a/language/sk/common.php
+++ b/language/sk/common.php
@@ -53,7 +53,7 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
 	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
-	'PRIMEPOSTREVISIONS_COMPARING'			=> ' Comparing post history',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing post history',
 	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between versions of the post.',
 	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected revisions',
 

--- a/language/sk/common.php
+++ b/language/sk/common.php
@@ -48,7 +48,6 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_FIRST'				=> 'Original prispevok',
 	'PRIMEPOSTREVISIONS_FINAL'				=> 'Aktuálny prispevok',
 	'PRIMEPOSTREVISIONS_COUNT'				=> 'Uprava %d',
-	#'PRIMEPOSTREVISIONS_INFO'				=> 'Upravil %1$s on %2$s.',
 	'PRIMEPOSTREVISIONS_EDIT_BY'			=> 'Upravil',
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[no subject]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',

--- a/language/sk/common.php
+++ b/language/sk/common.php
@@ -53,6 +53,10 @@ $lang = array_merge($lang, array(
 	'PRIMEPOSTREVISIONS_NO_SUBJECT'			=> '[no subject]',
 	'PRIMEPOSTREVISIONS_COMPARE'			=> 'Compare',
 	'PRIMEPOSTREVISIONS_VIEW_DENIED'		=> 'You lack the necessary permissions to view these post revisions.',
+	'PRIMEPOSTREVISIONS_COMPARISON'			=> 'Comparison',
+	'PRIMEPOSTREVISIONS_COMPARING'			=> 'Comparing two post history',
+	'PRIMEPOSTREVISIONS_COMPARING_EXPLAIN'	=> 'This page shows comparison between two versions of the post.',
+	'PRIMEPOSTREVISIONS_COMPARES'			=> 'Compare selected two revisions',
 
 	// Delete a revision
 	'PRIMEPOSTREVISIONS_DELETE'				=> 'Odstrániť Upravu',

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -88,12 +88,15 @@
 					<li>
 						<a href="{postrow.U_DELETE}" title="{L_PRIMEPOSTREVISIONS_DELETE}" class="button button-icon-only"><i class="icon fa-trash fa-fw"><span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETE}</span></i></a>
 					</li>
-					{% if SELECTABLE_CNT > 1 %}
+					{% if DELETABLE_CNT > 1 %}
 					<li>
-						<label class="button button-icon-only" style="padding-left:0.5em;padding-right:0.5em;"><input type="checkbox" id="revision_list_select_{postrow.REVISION_ID}" name="revision_list[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></label>
+						<label class="button button-icon"><i class="icon fa-trash fa-fw" style="padding-left:0.2em;padding-right:0.8em;">&nbsp;<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
 					</li>
 					{% endif %}
 					<!-- ENDIF -->
+					<li>
+						<label class="button button-icon"><i class="icon fa-balance-scale fa-fw" style="padding-left:0.2em;padding-right:1.3em;">&nbsp;<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
+					</li>
 				</ul>
 				<p class="author">
 					<span class="responsive-hide"><!-- IF postrow.EDIT_COUNT > 0 -->{L_PRIMEPOSTREVISIONS_EDIT_BY}<!-- ELSE -->{L_POST_BY_AUTHOR}<!-- ENDIF --> <strong>{postrow.POST_AUTHOR_FULL}</strong> &raquo; </span>{postrow.POST_DATE}
@@ -113,11 +116,30 @@
 <hr class="divider" />
 <!-- END postrow -->
 
-{% if SELECTABLE_CNT > 1 or COMPARISONS %}
+{% if DELETABLE_CNT > 1 or COMPARISONS %}
 <fieldset class="display-actions">
-	<!-- IF COMPARISONS --><input class="button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" /><!-- ENDIF -->
-	<input class="button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
-	<div><a href="#" onclick="marklist('revisions_form', 'revision', true); return false;">{L_MARK_ALL}</a> :: <a href="#" onclick="marklist('revisions_form', 'revision', false); return false;">{L_UNMARK_ALL}</a></div>
+	{% if COMPARISONS %}
+		<dl>
+			<dd>
+				<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevCmpActionBtn(); return false;">{L_MARK_ALL}</a>
+				&nbsp;{L_COLON}{L_COLON}&nbsp;
+				<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevCmpActionBtn(); return false;">{L_UNMARK_ALL}</a>
+				&nbsp;{L_COLON}{L_COLON}&nbsp;
+				<input class="button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
+			</dd>
+		</dl>
+	{% endif %}
+	{% if DELETABLE_CNT > 1 %}
+		<dl>
+			<dd>
+				<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevDelActionBtn(); return false;">{L_MARK_ALL}</a>
+				&nbsp;{L_COLON}{L_COLON}&nbsp;
+				<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevDelActionBtn(); return false;">{L_UNMARK_ALL}</a>
+				&nbsp;{L_COLON}{L_COLON}&nbsp;
+				<input class="button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
+			</dd>
+		</dl>
+	{% endif %}
 {S_HIDDEN_FIELDS}
 {S_FORM_TOKEN}
 </fieldset>

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -1,5 +1,5 @@
 <!-- INCLUDE overall_header.html -->
-<style>
+<style type="text/css" scoped>
 .ppr-post-checkbox {
 	padding-left: 0.2em;
 }
@@ -14,6 +14,12 @@
 }
 .ppr-action-dropdown {
 	display: inline-block;
+}
+#revisions_form .post-buttons ul.dropdown-contents .clone a.button-icon-only label {
+	padding-right:0;
+}
+.rtl #revisions_form .post-buttons ul.dropdown-contents .clone a.button-icon-only label {
+	padding-left:0;
 }
 </style>
 <h2><!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_TITLE}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING}<!-- ENDIF --></h2>
@@ -113,21 +119,21 @@
 					</li>
 					{% if DELETABLE_CNT > 1 %}
 					<li data-skip-responsive="true">
-						<label class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}">
-							<i class="icon fa-trash fa-fw ppr-post-checkbox">&nbsp;
-								<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
-							</i>
-						</label>
+						<a class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}"><label>
+							<i class="icon fa-trash fa-fw"></i>
+							<span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETES_SELECT}</span>
+							<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
+						</label></a>
 					</li>
 					{% endif %}
 					<!-- ENDIF -->
 					{% if COMPARISONS %}
 					<li data-skip-responsive="true">
-						<label class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}">
-							<i class="icon fa-balance-scale fa-fw ppr-post-checkbox">&nbsp;
-								<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
-							</i>
-						</label>
+						<a class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}"><label>
+							<i class="icon fa-balance-scale fa-fw"></i>
+							<span class="sr-only">{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}</span>
+							<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
+						</label></a>
 					</li>
 					{% endif %}
 				</ul>
@@ -153,7 +159,7 @@
 <div class="action-bar bar-bottom">
 	{% if DELETABLE_CNT > 1 %}
 	<div class="left-box">
-		<input class="button button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
+		<input class="button" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
 		<div class="dropdown-container dropdown-button-control dropdown-down dropdown-left ppr-action-dropdown">
 			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle">
 				<i class="icon fa-trash fa-fw" aria-hidden="true"></i>
@@ -167,10 +173,10 @@
 				</div>
 				<ul class="dropdown-contents">
 					<li>
-						<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown-container').click(); return false;">{L_MARK_ALL}</a>
 					</li>
 					<li>
-						<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown-container').click(); return false;">{L_UNMARK_ALL}</a>
 					</li>
 				</ul>
 			</div>
@@ -179,8 +185,8 @@
 	{% endif %}
 	{% if COMPARISONS %}
 	<div class="right-box">
-		<input class="button button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
-		<div class="dropdown-container dropdown-button-control dropdown-down ppr-action-dropdown">
+		<input class="button button-secondary" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
+		<div class="dropdown-container dropdown-button-control dropdown-down dropdown-left ppr-action-dropdown">
 			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle">
 				<i class="icon fa-balance-scale fa-fw" aria-hidden="true"></i>
 				<span class="caret">
@@ -193,10 +199,10 @@
 				</div>
 				<ul class="dropdown-contents">
 					<li>
-						<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown-container').click(); return false;">{L_MARK_ALL}</a>
 					</li>
 					<li>
-						<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown-container').click(); return false;">{L_UNMARK_ALL}</a>
 					</li>
 				</ul>
 			</div>

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -94,9 +94,11 @@
 					</li>
 					{% endif %}
 					<!-- ENDIF -->
+					{% if COMPARISONS %}
 					<li>
 						<label class="button button-icon"><i class="icon fa-balance-scale fa-fw" style="padding-left:0.2em;padding-right:1.3em;">&nbsp;<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
 					</li>
+					{% endif %}
 				</ul>
 				<p class="author">
 					<span class="responsive-hide"><!-- IF postrow.EDIT_COUNT > 0 -->{L_PRIMEPOSTREVISIONS_EDIT_BY}<!-- ELSE -->{L_POST_BY_AUTHOR}<!-- ENDIF --> <strong>{postrow.POST_AUTHOR_FULL}</strong> &raquo; </span>{postrow.POST_DATE}

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -110,7 +110,7 @@
 <hr class="divider" />
 <!-- END postrow -->
 
-{% if DELETABLE_CNT > 1 %}
+{% if DELETABLE_CNT > 1 or COMPARISONS %}
 <fieldset class="display-actions">
 	<!-- IF COMPARISONS --><input class="button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" /><!-- ENDIF -->
 	<input class="button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -90,13 +90,13 @@
 					</li>
 					{% if DELETABLE_CNT > 1 %}
 					<li>
-						<label class="button button-icon"><i class="icon fa-trash fa-fw" style="padding-left:0.2em;padding-right:0.8em;">&nbsp;<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
+						<label class="button button-icon" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}"><i class="icon fa-trash fa-fw" style="padding-left:0.2em;padding-right:0.8em;">&nbsp;<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
 					</li>
 					{% endif %}
 					<!-- ENDIF -->
 					{% if COMPARISONS %}
 					<li>
-						<label class="button button-icon"><i class="icon fa-balance-scale fa-fw" style="padding-left:0.2em;padding-right:1.3em;">&nbsp;<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
+						<label class="button button-icon" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}"><i class="icon fa-balance-scale fa-fw" style="padding-left:0.2em;padding-right:1.3em;">&nbsp;<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
 					</li>
 					{% endif %}
 				</ul>
@@ -119,32 +119,43 @@
 <!-- END postrow -->
 
 {% if DELETABLE_CNT > 1 or COMPARISONS %}
-<fieldset class="display-actions">
-	{% if COMPARISONS %}
-		<dl>
-			<dd>
-				<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevCmpActionBtn(); return false;">{L_MARK_ALL}</a>
-				&nbsp;{L_COLON}{L_COLON}&nbsp;
-				<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevCmpActionBtn(); return false;">{L_UNMARK_ALL}</a>
-				&nbsp;{L_COLON}{L_COLON}&nbsp;
-				<input class="button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
-			</dd>
-		</dl>
-	{% endif %}
+<div class="action-bar bar-bottom">
 	{% if DELETABLE_CNT > 1 %}
-		<dl>
-			<dd>
-				<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevDelActionBtn(); return false;">{L_MARK_ALL}</a>
-				&nbsp;{L_COLON}{L_COLON}&nbsp;
-				<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevDelActionBtn(); return false;">{L_UNMARK_ALL}</a>
-				&nbsp;{L_COLON}{L_COLON}&nbsp;
-				<input class="button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
-			</dd>
-		</dl>
+	<div class="left-box">
+		<input class="button" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
+		<!-- <label class="button button-icon"><i class="icon fa-trash fa-fw" style="padding-right:0.8em;">&nbsp;<input type="checkbox" id="toggle-all-delete" onclick="marklist('revisions_form', 'revision_list_delete[]', this.checked ? true : false);"></i></label> -->
+		<div class="dropdown-container dropdown-button-control dropdown-down" style="display:inline-block">
+			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle"><i class="icon fa-trash fa-fw" aria-hidden="true"></i><span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span></span>
+			<div class="dropdown">
+				<div class="pointer"><div class="pointer-inner"></div></div>
+				<ul class="dropdown-contents">
+					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a></li>
+					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
 	{% endif %}
+	{% if COMPARISONS %}
+	<div class="right-box">
+		<input class="button button-secondary" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
+		<!-- <label class="button button-icon"><i class="icon fa-balance-scale fa-fw" style="padding-right:1.3em;">&nbsp;<input type="checkbox" id="toggle-all-compare" onclick="marklist('revisions_form', 'revision_list_compare[]', this.checked ? true : false);"></i></label> -->
+		<div class="dropdown-container dropdown-button-control dropdown-down" style="display:inline-block">
+			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle"><i class="icon fa-balance-scale fa-fw" aria-hidden="true"></i><span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span></span>
+			<div class="dropdown">
+				<div class="pointer"><div class="pointer-inner"></div></div>
+				<ul class="dropdown-contents">
+					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a></li>
+					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+	{% endif %}
+
 {S_HIDDEN_FIELDS}
 {S_FORM_TOKEN}
-</fieldset>
+</div>
 {% endif %}
 </form>
 

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -1,4 +1,21 @@
 <!-- INCLUDE overall_header.html -->
+<style>
+.ppr-post-checkbox {
+	padding-left: 0.2em;
+}
+.fa-trash.ppr-post-checkbox {
+	padding-right: 1em;
+}
+.fa-balance-scale.ppr-post-checkbox {
+	padding-right: 1.5em;
+}
+.ppr-post-bbcode {
+	display: none;
+}
+.ppr-action-dropdown {
+	display: inline-block;
+}
+</style>
 <h2><!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_TITLE}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING}<!-- ENDIF --></h2>
 <p>
 	<!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_VIEWING_EXPLAIN}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING_EXPLAIN}<!-- ENDIF --><br>
@@ -95,22 +112,22 @@
 						</a>
 					</li>
 					{% if DELETABLE_CNT > 1 %}
-					<li>
-						<a class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}">
-							<i class="icon fa-trash fa-fw"></i>
-							<span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETES_SELECT}</span>
-							<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
-						</a>
+					<li data-skip-responsive="true">
+						<label class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}">
+							<i class="icon fa-trash fa-fw ppr-post-checkbox">&nbsp;
+								<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
+							</i>
+						</label>
 					</li>
 					{% endif %}
 					<!-- ENDIF -->
 					{% if COMPARISONS %}
-					<li>
-						<a class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}">
-							<i class="icon fa-balance-scale fa-fw"></i>
-							<span class="sr-only">{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}</span>
-							<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
-						</a>
+					<li data-skip-responsive="true">
+						<label class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}">
+							<i class="icon fa-balance-scale fa-fw ppr-post-checkbox">&nbsp;
+								<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
+							</i>
+						</label>
 					</li>
 					{% endif %}
 				</ul>
@@ -118,7 +135,7 @@
 					<span class="responsive-hide"><!-- IF postrow.EDIT_COUNT > 0 -->{L_PRIMEPOSTREVISIONS_EDIT_BY}<!-- ELSE -->{L_POST_BY_AUTHOR}<!-- ENDIF --> <strong>{postrow.POST_AUTHOR_FULL}</strong> &raquo; </span>{postrow.POST_DATE}
 				</p>
 				<div class="content">{postrow.POST_TEXT}</div>
-				<div class="bbcode" style="display:none;">{postrow.BBCODE_TEXT}</div>
+				<div class="ppr-post-bbcode">{postrow.BBCODE_TEXT}</div>
 
 				<!-- IF postrow.EDIT_REASON -->
 				<div class="notice">
@@ -136,8 +153,8 @@
 <div class="action-bar bar-bottom">
 	{% if DELETABLE_CNT > 1 %}
 	<div class="left-box">
-		<input class="button" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
-		<div class="dropdown-container dropdown-button-control dropdown-down" style="display:inline-block">
+		<input class="button button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
+		<div class="dropdown-container dropdown-button-control dropdown-down dropdown-left ppr-action-dropdown">
 			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle">
 				<i class="icon fa-trash fa-fw" aria-hidden="true"></i>
 				<span class="caret">
@@ -162,8 +179,8 @@
 	{% endif %}
 	{% if COMPARISONS %}
 	<div class="right-box">
-		<input class="button button-secondary" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
-		<div class="dropdown-container dropdown-button-control dropdown-down" style="display:inline-block">
+		<input class="button button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
+		<div class="dropdown-container dropdown-button-control dropdown-down ppr-action-dropdown">
 			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle">
 				<i class="icon fa-balance-scale fa-fw" aria-hidden="true"></i>
 				<span class="caret">

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -81,22 +81,36 @@
 				<ul class="post-buttons">
 					<!-- IF postrow.U_RESTORE -->
 					<li>
-						<a href="{postrow.U_RESTORE}" title="{L_PRIMEPOSTREVISIONS_RESTORE}" class="button button-icon-only"><i class="icon fa-undo fa-fw"><span class="sr-only">{L_PRIMEPOSTREVISIONS_RESTORE}</span></i></a>
+						<a href="{postrow.U_RESTORE}" title="{L_PRIMEPOSTREVISIONS_RESTORE}" class="button button-icon-only">
+							<i class="icon fa-undo fa-fw"></i>
+							<span class="sr-only">{L_PRIMEPOSTREVISIONS_RESTORE}</span>
+						</a>
 					</li>
 					<!-- ENDIF -->
 					<!-- IF postrow.U_DELETE -->
 					<li>
-						<a href="{postrow.U_DELETE}" title="{L_PRIMEPOSTREVISIONS_DELETE}" class="button button-icon-only"><i class="icon fa-trash fa-fw"><span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETE}</span></i></a>
+						<a href="{postrow.U_DELETE}" title="{L_PRIMEPOSTREVISIONS_DELETE}" class="button button-icon-only">
+							<i class="icon fa-trash fa-fw"></i>
+							<span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETE}</span>
+						</a>
 					</li>
 					{% if DELETABLE_CNT > 1 %}
 					<li>
-						<label class="button button-icon" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}"><i class="icon fa-trash fa-fw" style="padding-left:0.2em;padding-right:0.8em;">&nbsp;<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
+						<a class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_DELETES_SELECT}">
+							<i class="icon fa-trash fa-fw"></i>
+							<span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETES_SELECT}</span>
+							<input type="checkbox" id="revision_list_delete_{postrow.REVISION_ID}" name="revision_list_delete[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
+						</a>
 					</li>
 					{% endif %}
 					<!-- ENDIF -->
 					{% if COMPARISONS %}
 					<li>
-						<label class="button button-icon" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}"><i class="icon fa-balance-scale fa-fw" style="padding-left:0.2em;padding-right:1.3em;">&nbsp;<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></i></label>
+						<a class="button button-icon-only" title="{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}">
+							<i class="icon fa-balance-scale fa-fw"></i>
+							<span class="sr-only">{L_PRIMEPOSTREVISIONS_COMPARES_SELECT}</span>
+							<input type="checkbox" id="revision_list_compare_{postrow.REVISION_ID}" name="revision_list_compare[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> />
+						</a>
 					</li>
 					{% endif %}
 				</ul>
@@ -123,14 +137,24 @@
 	{% if DELETABLE_CNT > 1 %}
 	<div class="left-box">
 		<input class="button" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
-		<!-- <label class="button button-icon"><i class="icon fa-trash fa-fw" style="padding-right:0.8em;">&nbsp;<input type="checkbox" id="toggle-all-delete" onclick="marklist('revisions_form', 'revision_list_delete[]', this.checked ? true : false);"></i></label> -->
 		<div class="dropdown-container dropdown-button-control dropdown-down" style="display:inline-block">
-			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle"><i class="icon fa-trash fa-fw" aria-hidden="true"></i><span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span></span>
+			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle">
+				<i class="icon fa-trash fa-fw" aria-hidden="true"></i>
+				<span class="caret">
+					<i class="icon fa-sort-down fa-fw" aria-hidden="true"></i>
+				</span>
+			</span>
 			<div class="dropdown">
-				<div class="pointer"><div class="pointer-inner"></div></div>
+				<div class="pointer">
+					<div class="pointer-inner"></div>
+				</div>
 				<ul class="dropdown-contents">
-					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a></li>
-					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a></li>
+					<li>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', true); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a>
+					</li>
+					<li>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_delete[]', false); updatePrimePostRevActionBtn('delete'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a>
+					</li>
 				</ul>
 			</div>
 		</div>
@@ -139,20 +163,29 @@
 	{% if COMPARISONS %}
 	<div class="right-box">
 		<input class="button button-secondary" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" />
-		<!-- <label class="button button-icon"><i class="icon fa-balance-scale fa-fw" style="padding-right:1.3em;">&nbsp;<input type="checkbox" id="toggle-all-compare" onclick="marklist('revisions_form', 'revision_list_compare[]', this.checked ? true : false);"></i></label> -->
 		<div class="dropdown-container dropdown-button-control dropdown-down" style="display:inline-block">
-			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle"><i class="icon fa-balance-scale fa-fw" aria-hidden="true"></i><span class="caret"><i class="icon fa-sort-down fa-fw" aria-hidden="true"></i></span></span>
+			<span title="{L_MARK_ALL}/{L_UNMARK_ALL}" class="button button-secondary dropdown-trigger dropdown-select dropdown-toggle">
+				<i class="icon fa-balance-scale fa-fw" aria-hidden="true"></i>
+				<span class="caret">
+					<i class="icon fa-sort-down fa-fw" aria-hidden="true"></i>
+				</span>
+			</span>
 			<div class="dropdown">
-				<div class="pointer"><div class="pointer-inner"></div></div>
+				<div class="pointer">
+					<div class="pointer-inner"></div>
+				</div>
 				<ul class="dropdown-contents">
-					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a></li>
-					<li><a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a></li>
+					<li>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', true); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_MARK_ALL}</a>
+					</li>
+					<li>
+						<a href="#" onclick="marklist('revisions_form', 'revision_list_compare[]', false); updatePrimePostRevActionBtn('compare'); $(this).closest('.dropdown').hide(); return false;">{L_UNMARK_ALL}</a>
+					</li>
 				</ul>
 			</div>
 		</div>
 	</div>
 	{% endif %}
-
 {S_HIDDEN_FIELDS}
 {S_FORM_TOKEN}
 </div>

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -1,6 +1,9 @@
 <!-- INCLUDE overall_header.html -->
 <h2><!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_TITLE}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING}<!-- ENDIF --></h2>
-<p><!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_VIEWING_EXPLAIN}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING_EXPLAIN}<!-- ENDIF -->{% if U_POST %} <strong><em><a href="{U_POST}">{L_VIEW_LATEST_POST}</a></em></strong>{% endif %}</p>
+<p>
+	<!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_VIEWING_EXPLAIN}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING_EXPLAIN}<!-- ENDIF --><br>
+	{% if U_POST %}<strong><em><a href="{U_POST}">{L_VIEW_LATEST_POST}</a></em></strong>{% endif %}&nbsp;{% if S_FORM_ACTION and not COMPARISONS %} » <strong><em><a href="{S_FORM_ACTION}">{L_PRIMEPOSTREVISIONS_VIEW}</a></em></strong>{% endif %}
+</p>
 
 <form id="revisions_form" name="revisions_form" method="post" action="{S_FORM_ACTION}">
 <!-- BEGIN postrow -->
@@ -85,7 +88,7 @@
 					<li>
 						<a href="{postrow.U_DELETE}" title="{L_PRIMEPOSTREVISIONS_DELETE}" class="button button-icon-only"><i class="icon fa-trash fa-fw"><span class="sr-only">{L_PRIMEPOSTREVISIONS_DELETE}</span></i></a>
 					</li>
-					{% if DELETABLE_CNT > 1 %}
+					{% if SELECTABLE_CNT > 1 %}
 					<li>
 						<label class="button button-icon-only" style="padding-left:0.5em;padding-right:0.5em;"><input type="checkbox" id="revision_list_select_{postrow.REVISION_ID}" name="revision_list[]" value="{postrow.REVISION_ID}"<!-- IF postrow.S_CHECKED --> checked="checked"<!-- ENDIF --> /></label>
 					</li>
@@ -110,7 +113,7 @@
 <hr class="divider" />
 <!-- END postrow -->
 
-{% if DELETABLE_CNT > 1 or COMPARISONS %}
+{% if SELECTABLE_CNT > 1 or COMPARISONS %}
 <fieldset class="display-actions">
 	<!-- IF COMPARISONS --><input class="button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" /><!-- ENDIF -->
 	<input class="button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />

--- a/styles/all/template/body.html
+++ b/styles/all/template/body.html
@@ -1,6 +1,6 @@
 <!-- INCLUDE overall_header.html -->
-<h2>{L_PRIMEPOSTREVISIONS_TITLE}</h2>
-<p>{L_PRIMEPOSTREVISIONS_VIEWING_EXPLAIN}{% if U_POST %} <strong><em><a href="{U_POST}">{L_VIEW_LATEST_POST}</a></em></strong>{% endif %}</p>
+<h2><!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_TITLE}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING}<!-- ENDIF --></h2>
+<p><!-- IF COMPARISONS -->{L_PRIMEPOSTREVISIONS_VIEWING_EXPLAIN}<!-- ELSE -->{L_PRIMEPOSTREVISIONS_COMPARING_EXPLAIN}<!-- ENDIF -->{% if U_POST %} <strong><em><a href="{U_POST}">{L_VIEW_LATEST_POST}</a></em></strong>{% endif %}</p>
 
 <form id="revisions_form" name="revisions_form" method="post" action="{S_FORM_ACTION}">
 <!-- BEGIN postrow -->
@@ -112,7 +112,8 @@
 
 {% if DELETABLE_CNT > 1 %}
 <fieldset class="display-actions">
-	<input class="button1" type="submit" name="delete_revisions_submit" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
+	<!-- IF COMPARISONS --><input class="button2" type="submit" name="compare" value="{L_PRIMEPOSTREVISIONS_COMPARES}" /><!-- ENDIF -->
+	<input class="button1" type="submit" name="delete" value="{L_PRIMEPOSTREVISIONS_DELETES}" />
 	<div><a href="#" onclick="marklist('revisions_form', 'revision', true); return false;">{L_MARK_ALL}</a> :: <a href="#" onclick="marklist('revisions_form', 'revision', false); return false;">{L_UNMARK_ALL}</a></div>
 {S_HIDDEN_FIELDS}
 {S_FORM_TOKEN}

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -17,7 +17,7 @@
 </div>
 </script>
 <script id="ppr-cmpbtn-tpl" type="text/x-jsrender">
-<li>
+<li data-skip-responsive="true">
 	<a class="button icon-button compare" data-cmp="<<:cmpId>>" title="{L_PRIMEPOSTREVISIONS_COMPARE}">
 		<i class="icon fa-balance-scale fa-fw"></i>
 		<span class="sr-only">{L_PRIMEPOSTREVISIONS_COMPARE}</span>

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -33,7 +33,6 @@
 function cmpData($textA, $textB) {
 	let dmp		= new diff_match_patch();
 	let diffs	= dmp.diff_main($textA, $textB);
-
 	let cmpText	= dmp.diff_prettyHtml(diffs).replace(/&lt;(img.*)&gt;/g, '<$1>');
 	let matches = cmpText.match(/<ins [^>]+>(.*?)<\/ins>|<del [^>]+>(.*?)<\/del>/g)
 	if (matches != null)
@@ -42,7 +41,6 @@ function cmpData($textA, $textB) {
 			cmpText = cmpText.replace(val, val.replace(/&para;/g, '&crarr;'));
 		});
 	}
-
 	return cmpText.replace(/&para;/g, '');
 }
 
@@ -73,7 +71,7 @@ $('div.post').on('click', 'span.button.compare', function() {
 // Enable or disable the action buttons depending on if any of the checkboxes are checked
 function updatePrimePostRevActionBtn(type) {
 	let checkedCnt = $('#revisions_form input[name="revision_list_'+type+'[]"]:checkbox:checked').length;
-	let $btn = $('#revisions_form .display-actions input[name="'+type+'"]');
+	let $btn = $('#revisions_form input[type="submit"][name="'+type+'"]');
 	if (checkedCnt > 0) {
 		$btn.removeAttr('disabled').removeClass('disabled');
 	} else {
@@ -81,12 +79,12 @@ function updatePrimePostRevActionBtn(type) {
 	}
 }
 
-// Watch each checkbox to update the compare action buttons status when a change occurs
+// Watch each checkbox to update the compare action button status when a change occurs
 $('#revisions_form input[name="revision_list_compare[]"]').change(function() {
 	updatePrimePostRevActionBtn('compare');
 });
 
-// Watch each checkbox to update the delete action buttons status when a change occurs
+// Watch each checkbox to update the delete action button status when a change occurs
 $('#revisions_form input[name="revision_list_delete[]"]').change(function() {
 	updatePrimePostRevActionBtn('delete');
 });

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -62,5 +62,23 @@ $('div.post').on('click', 'span.button.compare', function() {
 	let cmpId = $(this).data('cmp');
 	$('#' + cmpId).slideToggle();
 });
+
+// Enable or disable the action buttons depending on if any of the checkboxes are checked
+function updatePrimePostRevActionBtns() {
+	let checkedCnt = $('#revisions_form input[name="revision_list[]"]:checkbox:checked').length;
+	let $btns = $('#revisions_form .display-actions input[type="submit"]');
+	if (checkedCnt > 0) {
+		$btns.removeAttr('disabled').removeClass('disabled');
+	} else {
+		$btns.attr('disabled', 'disabled').addClass('disabled');
+	}
+}
+
+// Watch each checkbox to update the action buttons status when a change occurs
+$('#revisions_form input[name="revision_list[]"]').change(function() {
+	updatePrimePostRevActionBtns();
+});
+updatePrimePostRevActionBtns();
+
 </script>
 {% endif %}

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -80,12 +80,12 @@ function updatePrimePostRevActionBtn(type) {
 }
 
 // Watch each checkbox to update the compare action button status when a change occurs
-$('#revisions_form input[name="revision_list_compare[]"]').change(function() {
+$('#revisions_form').on('change', 'input[name="revision_list_compare[]"]', function() {
 	updatePrimePostRevActionBtn('compare');
 });
 
 // Watch each checkbox to update the delete action button status when a change occurs
-$('#revisions_form input[name="revision_list_delete[]"]').change(function() {
+$('#revisions_form').on('change', 'input[name="revision_list_delete[]"]', function() {
 	updatePrimePostRevActionBtn('delete');
 });
 

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -25,6 +25,11 @@
 </script>
 {% INCLUDEJS '@primehalo_primepostrevisions/diff_match_patch.js' %}
 <script>
+/**
+ * Prime Post Revisions, JavaScript for revision comparison.
+ */
+
+// Compare 2 revisions
 function cmpData($textA, $textB) {
 	let dmp		= new diff_match_patch();
 	let diffs	= dmp.diff_main($textA, $textB);
@@ -41,6 +46,7 @@ function cmpData($textA, $textB) {
 	return cmpText.replace(/&para;/g, '');
 }
 
+// Compare all revisions with the adjacent post
 $postList = $('#revisions_form div.post');
 for (let i = 0, len = $postList.length; i < len - 1; i++) {
 	let $postA	= $postList.eq(i);
@@ -58,6 +64,7 @@ for (let i = 0, len = $postList.length; i < len - 1; i++) {
 	$postB.find('.post-buttons').prepend(cmpBtn);
 }
 
+// Toggle Diff post on click of compare button
 $('div.post').on('click', 'span.button.compare', function() {
 	let cmpId = $(this).data('cmp');
 	$('#' + cmpId).slideToggle();

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -70,41 +70,30 @@ $('div.post').on('click', 'span.button.compare', function() {
 	$('#' + cmpId).slideToggle();
 });
 
-// Enable or disable the delete action buttons depending on if any of the delete checkboxes are checked
-function updatePrimePostRevDelActionBtn() {
-	let checkedCnt = $('#revisions_form input[name="revision_list_delete[]"]:checkbox:checked').length;
-	let $btn = $('#revisions_form .display-actions input[name="delete"]');
+// Enable or disable the action buttons depending on if any of the checkboxes are checked
+function updatePrimePostRevActionBtn(type) {
+	let checkedCnt = $('#revisions_form input[name="revision_list_'+type+'[]"]:checkbox:checked').length;
+	let $btn = $('#revisions_form .display-actions input[name="'+type+'"]');
 	if (checkedCnt > 0) {
 		$btn.removeAttr('disabled').removeClass('disabled');
 	} else {
 		$btn.attr('disabled', 'disabled').addClass('disabled');
 	}
 }
-
-// Enable or disable the compare action buttons depending on if any of the compare checkboxes are checked
-function updatePrimePostRevCmpActionBtn() {
-	let checkedCnt = $('#revisions_form input[name="revision_list_compare[]"]:checkbox:checked').length;
-	let $btn = $('#revisions_form .display-actions input[name="compare"]');
-	if (checkedCnt > 0) {
-		$btn.removeAttr('disabled').removeClass('disabled');
-	} else {
-		$btn.attr('disabled', 'disabled').addClass('disabled');
-	}
-}
-
-// Watch each checkbox to update the delete action buttons status when a change occurs
-$('#revisions_form input[name="revision_list_delete[]"]').change(function() {
-	updatePrimePostRevDelActionBtn();
-});
 
 // Watch each checkbox to update the compare action buttons status when a change occurs
 $('#revisions_form input[name="revision_list_compare[]"]').change(function() {
-	updatePrimePostRevCmpActionBtn();
+	updatePrimePostRevActionBtn('compare');
+});
+
+// Watch each checkbox to update the delete action buttons status when a change occurs
+$('#revisions_form input[name="revision_list_delete[]"]').change(function() {
+	updatePrimePostRevActionBtn('delete');
 });
 
 // Run both once
-updatePrimePostRevDelActionBtn();
-updatePrimePostRevCmpActionBtn();
+updatePrimePostRevActionBtn('compare');
+updatePrimePostRevActionBtn('delete');
 
 </script>
 {% endif %}

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -51,8 +51,8 @@ for (let i = 0, len = $postList.length; i < len - 1; i++) {
 	let $postB	= $postList.eq(i + 1);
 	let $subjA	= $('h3 a', $postA).html().replace(/<br>/g, '');
 	let $subjB	= $('h3 a', $postB).html().replace(/<br>/g, '');
-	let $textA	= $('div.bbcode', $postA).html().replace(/<br>/g, '');
-	let $textB	= $('div.bbcode', $postB).html().replace(/<br>/g, '');
+	let $textA	= $('div.ppr-post-bbcode', $postA).html().replace(/<br>/g, '');
+	let $textB	= $('div.ppr-post-bbcode', $postB).html().replace(/<br>/g, '');
 	let cmpSubj	= cmpData($subjB, $subjA);
 	let cmpText	= cmpData($textB, $textA);
 	let cmpId	= 'cmp-' + i + '-' + (i + 1);

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -18,9 +18,10 @@
 </script>
 <script id="ppr-cmpbtn-tpl" type="text/x-jsrender">
 <li>
-	<span class="button icon-button compare" data-cmp="<<:cmpId>>" title="{L_PRIMEPOSTREVISIONS_COMPARE}">
-		<i class="icon fa-balance-scale fa-fw"><span class="sr-only">{L_PRIMEPOSTREVISIONS_COMPARE}</span></i>
-	</span>
+	<a class="button icon-button compare" data-cmp="<<:cmpId>>" title="{L_PRIMEPOSTREVISIONS_COMPARE}">
+		<i class="icon fa-balance-scale fa-fw"></i>
+		<span class="sr-only">{L_PRIMEPOSTREVISIONS_COMPARE}</span>
+	</a>
 </li>
 </script>
 {% INCLUDEJS '@primehalo_primepostrevisions/diff_match_patch.js' %}
@@ -35,8 +36,7 @@ function cmpData($textA, $textB) {
 	let diffs	= dmp.diff_main($textA, $textB);
 	let cmpText	= dmp.diff_prettyHtml(diffs).replace(/&lt;(img.*)&gt;/g, '<$1>');
 	let matches = cmpText.match(/<ins [^>]+>(.*?)<\/ins>|<del [^>]+>(.*?)<\/del>/g)
-	if (matches != null)
-	{
+	if (matches != null) {
 		matches.map(function(val) {
 			cmpText = cmpText.replace(val, val.replace(/&para;/g, '&crarr;'));
 		});
@@ -63,7 +63,7 @@ for (let i = 0, len = $postList.length; i < len - 1; i++) {
 }
 
 // Toggle Diff post on click of compare button
-$('div.post').on('click', 'span.button.compare', function() {
+$('div.post').on('click', 'a.compare', function() {
 	let cmpId = $(this).data('cmp');
 	$('#' + cmpId).slideToggle();
 });

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -70,22 +70,41 @@ $('div.post').on('click', 'span.button.compare', function() {
 	$('#' + cmpId).slideToggle();
 });
 
-// Enable or disable the action buttons depending on if any of the checkboxes are checked
-function updatePrimePostRevActionBtns() {
-	let checkedCnt = $('#revisions_form input[name="revision_list[]"]:checkbox:checked').length;
-	let $btns = $('#revisions_form .display-actions input[type="submit"]');
+// Enable or disable the delete action buttons depending on if any of the delete checkboxes are checked
+function updatePrimePostRevDelActionBtn() {
+	let checkedCnt = $('#revisions_form input[name="revision_list_delete[]"]:checkbox:checked').length;
+	let $btn = $('#revisions_form .display-actions input[name="delete"]');
 	if (checkedCnt > 0) {
-		$btns.removeAttr('disabled').removeClass('disabled');
+		$btn.removeAttr('disabled').removeClass('disabled');
 	} else {
-		$btns.attr('disabled', 'disabled').addClass('disabled');
+		$btn.attr('disabled', 'disabled').addClass('disabled');
 	}
 }
 
-// Watch each checkbox to update the action buttons status when a change occurs
-$('#revisions_form input[name="revision_list[]"]').change(function() {
-	updatePrimePostRevActionBtns();
+// Enable or disable the compare action buttons depending on if any of the compare checkboxes are checked
+function updatePrimePostRevCmpActionBtn() {
+	let checkedCnt = $('#revisions_form input[name="revision_list_compare[]"]:checkbox:checked').length;
+	let $btn = $('#revisions_form .display-actions input[name="compare"]');
+	if (checkedCnt > 0) {
+		$btn.removeAttr('disabled').removeClass('disabled');
+	} else {
+		$btn.attr('disabled', 'disabled').addClass('disabled');
+	}
+}
+
+// Watch each checkbox to update the delete action buttons status when a change occurs
+$('#revisions_form input[name="revision_list_delete[]"]').change(function() {
+	updatePrimePostRevDelActionBtn();
 });
-updatePrimePostRevActionBtns();
+
+// Watch each checkbox to update the compare action buttons status when a change occurs
+$('#revisions_form input[name="revision_list_compare[]"]').change(function() {
+	updatePrimePostRevCmpActionBtn();
+});
+
+// Run both once
+updatePrimePostRevDelActionBtn();
+updatePrimePostRevCmpActionBtn();
 
 </script>
 {% endif %}


### PR DESCRIPTION
Add the ability for Comparisons of selected Revisions.

Working : 
If 0 selection of Revision is done , then produce an Err0r.
If 1 selection of Revision is done , then compare selected revision with current Post.
If 2 or more selection of Revisions is done , then compare all selected revision.
~~If 3 or more selection of Revisions is done , then compare Max & Min revision using ID.~~

On Viewing Page : 
![1](https://user-images.githubusercontent.com/25451052/79417698-62754880-7fd0-11ea-8e2a-df0c1b27c0a8.png)

On Comparisons of 2 Revisions Page : 
![0](https://user-images.githubusercontent.com/25451052/79417718-71f49180-7fd0-11ea-81f9-441f10683e6f.PNG)

I have added all Lang Keys in other Lang Files.

I hope you like it.
If any changes are required , then let me know.

Best regards 👍